### PR TITLE
feat: FLIR Camera calibration

### DIFF
--- a/src/v4l2_camera/boson:_flir_video.yaml
+++ b/src/v4l2_camera/boson:_flir_video.yaml
@@ -1,0 +1,26 @@
+image_width: 640
+image_height: 512
+camera_name: boson:_flir_video
+camera_matrix:
+  rows: 3
+  cols: 3
+  data: [500.0,   0.0, 320.0,
+           0.0, 500.0, 256.0,
+           0.0,   0.0,   1.0]
+distortion_model: plumb_bob
+distortion_coefficients:
+  rows: 1
+  cols: 5
+  data: [0.0, 0.0, 0.0, 0.0, 0.0]
+rectification_matrix:
+  rows: 3
+  cols: 3
+  data: [1.0, 0.0, 0.0,
+         0.0, 1.0, 0.0,
+         0.0, 0.0, 1.0]
+projection_matrix:
+  rows: 3
+  cols: 4
+  data: [500.0,   0.0, 320.0, 0.0,
+           0.0, 500.0, 256.0, 0.0,
+           0.0,   0.0,   1.0, 0.0]

--- a/src/v4l2_camera/v4l2_camera.yaml
+++ b/src/v4l2_camera/v4l2_camera.yaml
@@ -1,8 +1,59 @@
 /v4l2_camera:
   ros__parameters:
+    camera_frame_id: camera
+    camera_info_url: "file:///home/your-path-here/src/v4l2_camera/boson:_flir_video.yaml"
+    image_raw:
+      compressed:
+        format: png
+        jpeg_quality: 95
+        png_level: 3
+        tiff:
+          res_unit: inch
+          xdpi: -1
+          ydpi: -1
+      compressedDepth:
+        depth_max: 10.0
+        depth_quantization: 100.0
+        format: png
+        png_level: 3
+      depth_max: 10.0
+      depth_quantization: 100.0
+      enable_pub_plugins:
+        - image_transport/compressedDepth
+        - image_transport/compressed
+        - image_transport/raw
+        - image_transport/theora
+        - image_transport/zstd
+      format: png
+      jpeg_quality: 95
+      keyframe_frequency: 64
+      optimize_for: true
+      png_level: 3
+      quality: 31
+      target_bitrate: 800000
+      theora:
+        keyframe_frequency: 64
+        optimize_for: true
+        quality: 31
+        target_bitrate: 800000
+      tiff:
+        res_unit: inch
+        xdpi: -1
+        ydpi: -1
+      zstd:
+        zstd_level: 3
     image_size:
       - 640
       - 512
     output_encoding: mono16
     pixel_format: "Y16 "
+    qos_overrides:
+      /parameter_events:
+        publisher:
+          depth: 1000
+          durability: volatile
+          history: keep_last
+          reliability: reliable
+    start_type_description_service: true
+    use_sim_time: false
     video_device: /dev/video4


### PR DESCRIPTION
Added calibration file for the FLIR Cameras to allow for use of /image_raw/compressed. Without it the Rviz2 is unable to display the images. Also added all possible parameters for the FLIR Cameras. Main changes there is the /image_raw/compressed format being png, and camera_info_url to tell the camera where the calibration file is located. **This should be absolute path, and is different for everyone. Make sure to change it for yourself.**