### PR TITLE
fix: Change stereocamera fps to 30

### DIFF
--- a/src/multisense_stereo_camera/multisense_ros/src/multisense_parameters.yaml
+++ b/src/multisense_stereo_camera/multisense_ros/src/multisense_parameters.yaml
@@ -4,7 +4,7 @@ multisense:
       description: "Operating resolution for the MultiSense stored as [width, height, disparity]"
   fps:
       type: int
-      default_value: 10
+      default_value: 30
       description: "The number of image frames per second the camera will send"
       validation:
           bounds<>: [1, 30]


### PR DESCRIPTION
Switched the default fps parameter of the stereo camera to 30 instead of the default 10, enabling us to acquire more data per second, at the cost of more bandwidth.