### PR TITLE
chore: Change namespace of flirs to left and right

### DIFF
--- a/launch/main_launch.py
+++ b/launch/main_launch.py
@@ -21,8 +21,8 @@ def generate_launch_description():
                 name="flir_driver",
                 package="v4l2_camera",
                 executable="v4l2_camera_node",
-                namespace="flir_1",
-                remappings=[("/image_raw", "/flir_1/image_raw")],
+                namespace="flir_left",
+                remappings=[("/image_raw", "/flir_left/image_raw")],
                 parameters=[
                     {
                         "output_encoding": "mono16",
@@ -36,8 +36,8 @@ def generate_launch_description():
                 name="flir_driver2",
                 package="v4l2_camera",
                 executable="v4l2_camera_node",
-                namespace="flir_2",
-                remappings=[("/image_raw", "/flir_2/image_raw")],
+                namespace="flir_right",
+                remappings=[("/image_raw", "/flir_right/image_raw")],
                 parameters=[
                     {
                         "output_encoding": "mono16",
@@ -81,13 +81,13 @@ def generate_launch_description():
                     f"bags/{time}",
                     "--topics",
                     "/lidar_points",
-                    "/flir_1/image_raw",
+                    "/flir_left/image_raw",
                     "/aux/image_color",
                     "/left/cost",
                     "/left/depth",
                     "/left/image_rect",
                     "/right/image_rect",
-                    "/flir_2/image_raw",
+                    "/flir_right/image_raw",
                     "/lidar_imu",
                 ],
                 output="screen",

--- a/launch/main_nonrecord_launch.py
+++ b/launch/main_nonrecord_launch.py
@@ -21,8 +21,8 @@ def generate_launch_description():
                 name="flir_driver",
                 package="v4l2_camera",
                 executable="v4l2_camera_node",
-                namespace="flir_1",
-                remappings=[('/image_raw', '/flir_1/image_raw')],
+                namespace="flir_left",
+                remappings=[('/image_raw', '/flir_left/image_raw')],
                 parameters=[
                     {
                         "output_encoding": "mono16",
@@ -36,8 +36,8 @@ def generate_launch_description():
                 name="flir_driver2",
                 package="v4l2_camera",
                 executable="v4l2_camera_node",
-                namespace="flir_2",
-                remappings=[('/image_raw', '/flir_2/image_raw')],
+                namespace="flir_right",
+                remappings=[('/image_raw', '/flir_right/image_raw')],
                 parameters=[
                     {
                         "output_encoding": "mono16",


### PR DESCRIPTION
Changed the namespace of flir_1 and flir_2 to flir_left and flir_right. These are the names that should be used from now on, and the cameras and usb ports have been labeled to retain the correct usb port allocation. In the future image rotation will be done according to the name.